### PR TITLE
Feat: 단품/세트 선택 페이지

### DIFF
--- a/src/component/menu-list/FilteredMenuList.tsx
+++ b/src/component/menu-list/FilteredMenuList.tsx
@@ -15,7 +15,7 @@ const FilteredMenuList = ({ items }: Props) => {
           <li
             key={item.id}
             className="bg-[#F8F8F8] rounded-[10px] text-center cursor-pointer"
-            onClick={() => naviate('/set-choice')}
+            onClick={() => naviate(`/set-choice/${item.id}`)}
           >
             <div className='mb-2'>
               <img

--- a/src/pages/SetSelection.tsx
+++ b/src/pages/SetSelection.tsx
@@ -1,7 +1,47 @@
+import { Button } from "@/components/ui/button";
+import { useNavigate, useParams } from "react-router-dom";
+import { cn } from '@/lib/utils';
+
+import { menu_items } from '../assets/data/menu.json';
+
 const SetSelection = () => {
+  const params = useParams();
+  const id = params.itemId;
+  const [ menu ] = menu_items.filter((item) => item.id === id);
+
   return (
-    <div>세트 선택</div>
+    <div className="p-[30px] pt-[60px] grid grid-rows-[auto_1fr_auto] gap-[20px] max-w-screen-sm relative h-screen sm:m-auto text-mc_black text-center">
+      <header className="mb-[20px]">
+        <h2 className="mb-[10px] text-[30px] font-bold sm:text-[40px]">{menu.name}</h2>
+        <p className="text-base sm:text-lg">세트 여부를 선택해주세요</p>
+      </header>
+     <div className="flex h-[230px] sm:h-[350px] justify-around sm:my-auto">
+        <SetSelectButton icon="🍔" title="햄버거만" classname="bg-white border border-solid border-mc_yellow  hover:bg-inherit"/>
+        <SetSelectButton icon="🍔🍟🥤" title="기본 세트" description="(버거 + 사이드 + 음료)" classname="bg-mc_yellow hover:bg-mc_yellow"/>
+     </div>
+     <Button size='lg' variant='secondary' className="w-full sm:max-w-[450px] m-auto text-lg">취소</Button>
+    </div>
   )
 }
 
 export default SetSelection;
+
+type Props = {
+  icon: string;
+  title: string;
+  description?: string;
+  classname?: string;
+}
+
+const SetSelectButton = ({ classname, icon, title, description }: Props) => {
+  const navigate = useNavigate();
+  return (
+    <Button className={cn("w-[150px] h-full sm:w-[250px] text-mc_black", classname)} onClick={() => navigate('/menu-select')}>
+    <div className="flex flex-col items-center justify-center">
+      <p className="text-[30px] sm:text-[40px]">{icon}</p>
+      <p className="mt-5 text-base sm:text-[24px]">{title}</p>
+      <p className="text-sm sm:text-lg">{description}</p>
+    </div>
+  </Button>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,7 +21,7 @@ const routes = createBrowserRouter([
         element: <MenuList />,
     },
     {
-        path: '/set-choice',
+        path: '/set-choice/:itemId',
         element: <SetSelection />
     },
     {


### PR DESCRIPTION
단품/세트 선택 페이지 화면 구성

라우트 경로 수정 
- 메뉴 리스트에서 메뉴 아이템 클릭 후 세트 선택 화면으로 이동 시 아이템 아이디를 parameter로 보냄
- /set-choice -> /set-choice/:itemId
