### PR TITLE
Fix: 단품/세트 선택 화면

### DIFF
--- a/src/component/menu-list/FilteredMenuList.tsx
+++ b/src/component/menu-list/FilteredMenuList.tsx
@@ -47,7 +47,7 @@ const FilteredMenuList = ({ items }: Props) => {
       {items.map((item) => (
         <li
           key={item.id}
-          className="bg-[#F8F8F8] rounded-[10px] text-center cursor-pointer"
+          className="sm:max-h-[220px] bg-[#F8F8F8] rounded-[10px] text-center cursor-pointer"
           onClick={() => naviate(`/set-choice/${item.id}`)}
         >
           <div className='mb-2'>

--- a/src/pages/SetSelection.tsx
+++ b/src/pages/SetSelection.tsx
@@ -2,14 +2,15 @@ import { Button } from "@/components/ui/button";
 import { useNavigate, useParams } from "react-router-dom";
 import { cn } from "@/lib/utils";
 
-import { menu_items } from "../assets/data/menu.json";
+import { menu_items, meals } from "../assets/data/menu.json";
 
+const burgerCategoryId = '3fefc837-88f7-4d53-a8b8-5a8c45c06b84';
 const SetSelection = () => {
     const navigate = useNavigate();
     const params = useParams();
     const id = params.itemId;
-    const [menu] = menu_items.filter((item) => item.id === id);
-
+    const [ menu ] = menu_items.filter((item) => item.id === id);
+    const setMenu = meals.filter((meal) => meal.items.includes(menu.id))[0] || null;
     const handleNavigate = (path: string) => {
         navigate(`${path}`);
     };
@@ -20,22 +21,22 @@ const SetSelection = () => {
                 <h2 className="mb-[10px] text-[30px] font-bold sm:text-[40px]">
                     {menu.name}
                 </h2>
-                <p className="text-base sm:text-lg">세트 여부를 선택해주세요</p>
+                <p className="text-base sm:text-lg">{setMenu ? '세트 여부를 선택해주세요' : '이 상품은 단일 상품이에요'}</p>
             </header>
             <div className="flex h-[230px] sm:h-[350px] justify-around sm:my-auto">
                 <SetSelectButton
-                    icon="🍔"
-                    title="햄버거만"
+                    imageUrl={menu.image_url}
+                    title={menu.name}
                     classname="bg-white border border-solid border-mc_yellow hover:bg-inherit"
                     onNavigate={() => handleNavigate(`/menu-select/${menu.id}`)}
                 />
-                <SetSelectButton
+               { setMenu && <SetSelectButton
                     icon="🍔🍟🥤"
                     title="기본 세트"
                     description="(버거 + 사이드 + 음료)"
                     classname="bg-mc_yellow hover:bg-mc_yellow"
-                    onNavigate={() => handleNavigate(`/menu-select/${menu.id}`)}
-                />
+                    onNavigate={() => handleNavigate(`/menu-select/${setMenu.id}`)}
+                /> }
             </div>
             <Button
                 size="lg"
@@ -52,11 +53,12 @@ const SetSelection = () => {
 export default SetSelection;
 
 type Props = {
-    icon: string;
+    icon?: string;
     title: string;
     description?: string;
     classname?: string;
-    onNavigate: (path: string) => void;
+    onNavigate: () => void;
+    imageUrl?: string;
 };
 
 const SetSelectButton = ({
@@ -64,20 +66,24 @@ const SetSelectButton = ({
     icon,
     title,
     description,
-    onNavigate
+    onNavigate,
+    imageUrl
 }: Props) => {
-    const params = useParams();
-    const id = params.itemId;
     return (
         <Button
             className={cn(
                 "w-[150px] h-full sm:w-[250px] text-mc_black",
                 classname
             )}
-            onClick={() => onNavigate(`/menu-select/${id}`)}
+            onClick={onNavigate}
         >
             <div className="flex flex-col items-center justify-center">
-                <p className="text-[30px] sm:text-[40px]">{icon}</p>
+                {
+                    imageUrl && <div>
+                        <img src={imageUrl} alt="단일 상품 이미지" />
+                    </div>
+                }
+                {icon && <p className="text-[30px] sm:text-[40px]">{icon}</p>}
                 <p className="mt-5 text-base sm:text-[24px]">{title}</p>
                 <p className="text-sm sm:text-lg">{description}</p>
             </div>


### PR DESCRIPTION
-세트 클릭시 세트 아이디넘김
-기존에는 버거가 아닌 음료, 사이드만 선택했을 때도 단품/세트 선택 버튼이 보였는데
버거가 아닌 단일 상품인 경우 단품 선택 버튼만 존재하게 수정
-메뉴 리스트 아이템 높이 수정