### PR TITLE
모의 결제 달기

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -18,6 +18,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.iamport.kr/v1/iamport.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/OrderItemInCart.tsx
+++ b/src/components/OrderItemInCart.tsx
@@ -1,81 +1,84 @@
 import { MenuItemWithCount } from "@/types/menu.interface";
 import { Button } from "@/components/ui/button";
 import {
-    modifyItemFromOrderInfo,
-    setItemToOrderInfo,
-    getOrderInfo,
-    deleteItemFromOrderInfo
+  modifyItemFromOrderInfo,
+  setItemToOrderInfo,
+  getOrderInfo,
+  deleteItemFromOrderInfo,
 } from "@/feat/order";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { usePaymentCostStore } from "@/store/paymentCostStore";
 
 type OrderItemInCartProps = {
-    item: MenuItemWithCount;
-    setOrderItemCount: (items: MenuItemWithCount[]) => boolean | void;
+  item: MenuItemWithCount;
+  setOrderItemCount: (items: MenuItemWithCount[]) => boolean | void;
 };
 
 const OrderItemInCart = ({ item, setOrderItemCount }: OrderItemInCartProps) => {
-    const [itemCost, setItemCost] = useState(item.price * item.count);
+  const [itemCost, setItemCost] = useState(item.price * item.count);
+  const { setPrice } = usePaymentCostStore();
 
-    const modifyCount = (type: string, item: MenuItemWithCount) => {
-        if (type === "increase") {
-            setItemToOrderInfo(item);
-            setItemCost(item.price * (item.count + 1));
-        } else {
-            modifyItemFromOrderInfo(item);
-            setItemCost(item.price * (item.count - 1));
-        }
-
-        setOrderItemCount(getOrderInfo().orderItem || []);
-    };
-
-    const resetMenu = (item: MenuItemWithCount) => {
-        if (window.confirm("정말로 삭제하시겠습니까?")) {
-            deleteItemFromOrderInfo(item);
-            setOrderItemCount(getOrderInfo().orderItem || []);
-        }
-    };
-
-    return (
-        <div key={item.id} className="flex justify-center items-center gap-2">
-            <img
-                src={item.image_url}
-                alt="메뉴"
-                className="w-36 h-36 object-cover"
-            />
-            <div className="w-[60%]">
-                <p className="text-2xl font-bold">
-                    {item.name}
-                </p>
-                <p className="font-semibold text-2xl mb-2">
-                    {itemCost.toLocaleString()}원
-                </p>
-                <div className="flex justify-center items-center gap-2">
-                    <button
-                        onClick={() => modifyCount("decrease", item)}
-                        disabled={item.count === 1}
-                        className="w-8 h-8 flex items-center justify-center bg-white rounded-full border border-gray-300"
-                    >
-                        -
-                    </button>
-                    <span>
-                        {item.count}
-                    </span>
-                    <button
-                        onClick={() => modifyCount("increase", item)}
-                        className="w-8 h-8 flex items-center justify-center bg-white rounded-full border border-gray-300"
-                    >
-                        +
-                    </button>
-                    <Button
-                        onClick={() => resetMenu(item)}
-                        className="text-lg text-black ml-2 bg-mc_red hover:bg-mc_red/90 px-4 py-2 rounded-md"
-                    >
-                        취소
-                    </Button>
-                </div>
-            </div>
-        </div>
+  useEffect(() => {
+    const totalCost = getOrderInfo().orderItem?.reduce(
+      (acc, item) => acc + item.price * item.count,
+      0,
     );
+
+    setPrice(totalCost || 0);
+  }, [itemCost, setPrice]);
+
+  const modifyCount = (type: string, item: MenuItemWithCount) => {
+    if (type === "increase") {
+      setItemToOrderInfo(item);
+      setItemCost(item.price * (item.count + 1));
+    } else {
+      modifyItemFromOrderInfo(item);
+      setItemCost(item.price * (item.count - 1));
+    }
+
+    setOrderItemCount(getOrderInfo().orderItem || []);
+  };
+
+  const resetMenu = (item: MenuItemWithCount) => {
+    if (window.confirm("정말로 삭제하시겠습니까?")) {
+      deleteItemFromOrderInfo(item);
+      setOrderItemCount(getOrderInfo().orderItem || []);
+    }
+  };
+
+  return (
+    <div key={item.id} className="flex justify-center items-center gap-2">
+      <img src={item.image_url} alt="메뉴" className="w-36 h-36 object-cover" />
+      <div className="w-[60%]">
+        <p className="text-2xl font-bold">{item.name}</p>
+        <p className="font-semibold text-2xl mb-2">
+          {itemCost.toLocaleString()}원
+        </p>
+        <div className="flex justify-center items-center gap-2">
+          <button
+            onClick={() => modifyCount("decrease", item)}
+            disabled={item.count === 1}
+            className="w-8 h-8 flex items-center justify-center bg-white rounded-full border border-gray-300"
+          >
+            -
+          </button>
+          <span>{item.count}</span>
+          <button
+            onClick={() => modifyCount("increase", item)}
+            className="w-8 h-8 flex items-center justify-center bg-white rounded-full border border-gray-300"
+          >
+            +
+          </button>
+          <Button
+            onClick={() => resetMenu(item)}
+            className="text-lg text-black ml-2 bg-mc_red hover:bg-mc_red/90 px-4 py-2 rounded-md"
+          >
+            취소
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default OrderItemInCart;

--- a/src/pages/CardPayment.tsx
+++ b/src/pages/CardPayment.tsx
@@ -3,6 +3,7 @@ import CardPaymentImage from "../assets/image/card-payment.png";
 import { Button } from "@/components/ui/button";
 import { completeOrder } from "@/feat/order";
 import useSpeechFeedback from "@/hooks/useSpeechFeedback";
+import { usePaymentCostStore } from "@/store/paymentCostStore";
 
 interface CustomWindow extends Window {
   IMP: any;
@@ -13,7 +14,35 @@ declare let window: CustomWindow;
 const { IMP } = window;
 IMP.init("imp01813062");
 
+interface IMPProps {
+  success: boolean;
+  imp_uid: string;
+  pay_method: string;
+  merchant_uid: string;
+  name: string;
+  paid_amount: number;
+  currency: "KRW";
+  pg_provider: string;
+  pg_type: string;
+  pg_tid: string;
+  apply_num: string;
+  buyer_name: string;
+  buyer_email: string;
+  buyer_tel: string;
+  buyer_addr: string;
+  buyer_postcode: string;
+  custom_data: null;
+  status: string;
+  paid_at: number;
+  receipt_url: string;
+  card_name: null;
+  bank_name: null;
+  card_quota: number;
+  card_number: string;
+}
+
 const CardPayment = () => {
+  const { price } = usePaymentCostStore();
   const { speak } = useSpeechFeedback();
   const naviate = useNavigate();
 
@@ -26,15 +55,22 @@ const CardPayment = () => {
     if (!result) {
       alert("주문에 오류가 발생했습니다");
     }
-    IMP.request_pay({
-      pg: "kakaopay",
-      pay_method: "card",
-      merchant_uid: "merchant_" + new Date().getTime(),
-      name: "주문명:결제테스트",
-      amount: 14000,
-      buyer_email: "",
-    });
-    speak("결제가 완료되었습니다.");
+    IMP.request_pay(
+      {
+        pg: "kakaopay",
+        pay_method: "card",
+        merchant_uid: "merchant_" + new Date().getTime(),
+        name: "주문명:결제테스트",
+        amount: price,
+        buyer_email: "",
+      },
+      function (response: IMPProps) {
+        response.success
+          ? speak("결제가 완료되었습니다.")
+          : alert("결제에 실패했습니다.");
+      },
+    );
+
     naviate("/payment-result");
   };
 

--- a/src/pages/CardPayment.tsx
+++ b/src/pages/CardPayment.tsx
@@ -4,6 +4,15 @@ import { Button } from "@/components/ui/button";
 import { completeOrder } from "@/feat/order";
 import useSpeechFeedback from "@/hooks/useSpeechFeedback";
 
+interface CustomWindow extends Window {
+  IMP: any;
+}
+
+declare let window: CustomWindow;
+
+const { IMP } = window;
+IMP.init("imp01813062");
+
 const CardPayment = () => {
   const { speak } = useSpeechFeedback();
   const naviate = useNavigate();
@@ -17,6 +26,14 @@ const CardPayment = () => {
     if (!result) {
       alert("주문에 오류가 발생했습니다");
     }
+    IMP.request_pay({
+      pg: "kakaopay",
+      pay_method: "card",
+      merchant_uid: "merchant_" + new Date().getTime(),
+      name: "주문명:결제테스트",
+      amount: 14000,
+      buyer_email: "",
+    });
     speak("결제가 완료되었습니다.");
     naviate("/payment-result");
   };

--- a/src/pages/OrderHistory.tsx
+++ b/src/pages/OrderHistory.tsx
@@ -7,15 +7,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  getOrderInfo,
-} from "@/feat/order";
+import { getOrderInfo } from "@/feat/order";
 import OrderItemInCart from "@/components/OrderItemInCart";
 
 const OrderHistory = () => {
   const navigate = useNavigate();
-  const [orderItemData, setOrderItemData] = useState(getOrderInfo().orderItem || []);
-
+  const [orderItemData, setOrderItemData] = useState(
+    getOrderInfo().orderItem || [],
+  );
 
   const openPointVerificationPage = () => {
     navigate("/point-collection");

--- a/src/store/paymentCostStore.ts
+++ b/src/store/paymentCostStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface PaymentCostStore {
+  name: string;
+  price: number;
+  setPrice: (price: number) => void;
+}
+
+export const usePaymentCostStore = create<PaymentCostStore>((set) => ({
+  name: "paymentCostStore",
+  price: 0,
+  setPrice: (price: number) => set({ price }),
+}));


### PR DESCRIPTION
- 포트원을 이용해서 모의 결제를 진행했고 현재는 카카오페이로 진행했습니다.
- 장바구니에 담은 메뉴 가격을 `usePaymentCostStore` 로 받아서 최종 결제 시에 반영되도록 했는데, 이 부분은 추후에 상태 관리가 필요없다고 판단되면 수정할 예정입니다.
- 현재 포트원 식별 코드가 하드코딩 되어있는데 이 부분은 같이 논의해봐도 좋을 것 같습니다.
[참고링크](https://admin.portone.io/)